### PR TITLE
Michael/wal 1190 fork clerkjavascript and patch

### DIFF
--- a/README-WALLABI.md
+++ b/README-WALLABI.md
@@ -1,0 +1,7 @@
+This repository is a fork of [Clerk's javascript repo](https://github.com/clerk/javascript) with some small changes. See [WAL-1190](https://linear.app/wallabi/issue/WAL-1190/fork-clerkjavascript-and-patch) for details.
+
+To build/deploy into Wallabi:
+
+1.  `pnpm build`
+1.  `cp packages/clerk-js/dist/*.js ~/${WALLABI_APP_DIR}/public/clerk/`
+1.  Publish and merge the changes to Wallabi

--- a/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
+++ b/packages/clerk-js/src/core/auth/cookies/devBrowser.ts
@@ -26,7 +26,8 @@ export const createDevBrowserCookie = (cookieSuffix: string): DevBrowserCookieHa
 
   const set = (jwt: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
+    // WAL-1190 - Set sameSite to 'None' in all cases
+    const sameSite = inCrossOriginIframe() ? 'None' : 'None';
     const secure = getSecureAttribute(sameSite);
 
     suffixedDevBrowserCookie.set(jwt, { expires, sameSite, secure });

--- a/packages/clerk-js/src/core/auth/cookies/session.ts
+++ b/packages/clerk-js/src/core/auth/cookies/session.ts
@@ -28,7 +28,8 @@ export const createSessionCookie = (cookieSuffix: string): SessionCookieHandler 
 
   const set = (token: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = inCrossOriginIframe() ? 'None' : 'Lax';
+    // WAL-1190 - Set sameSite to 'None' in all cases
+    const sameSite = inCrossOriginIframe() ? 'None' : 'None';
     const secure = getSecureAttribute(sameSite);
 
     suffixedSessionCookie.set(token, { expires, sameSite, secure });


### PR DESCRIPTION
Overrides JWT cookie settings to use SameSite: None. This makes the latest version of Clerk functional within Wallabi. 

I also played with adding `partitioned` to the JWT cookie. This works but doesn't really change anything so I left it out for now.